### PR TITLE
Update scraper API for selector lib v0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,10 @@ repository = "https://github.com/programble/scraper"
 readme = "README.md"
 
 [dependencies]
-cssparser = "0.13"
+cssparser = "0.23.2"
 ego-tree = "0.2.0"
-html5ever = "0.21.0"
+html5ever = "0.22.0"
 matches = "0.1.6"
-selectors = "0.18.0"
+selectors = "0.19.0"
 tendril = "0.4.0"
+smallvec = "0.6.0"

--- a/src/element_ref/element.rs
+++ b/src/element_ref/element.rs
@@ -116,3 +116,80 @@ impl<'a> Element for ElementRef<'a> {
     }
 
 }
+
+#[cfg(test)]
+mod tests {
+    use html::Html;
+    use selector::Selector;
+    use selectors::Element;
+    use selectors::attr::CaseSensitivity;
+
+    #[test]
+    fn test_has_id() {
+        use html5ever::LocalName;
+
+        let html = "<p id='link_id_456'>hey there</p>";
+        let fragment = Html::parse_fragment(html);
+        let sel = Selector::parse("p").unwrap();
+
+        let element = fragment.select(&sel).next().unwrap();
+        assert_eq!(
+            true,
+            element.has_id(
+                &LocalName::from("link_id_456"),
+                CaseSensitivity::CaseSensitive
+            )
+        );
+
+        let html = "<p>hey there</p>";
+        let fragment = Html::parse_fragment(html);
+        let element = fragment.select(&sel).next().unwrap();
+        assert_eq!(
+            false,
+            element.has_id(
+                &LocalName::from("any_link_id"),
+                CaseSensitivity::CaseSensitive
+            )
+        );
+    }
+
+    #[test]
+    fn test_is_link() {
+        let html = "<a href='https://www.example.com'>Example website</a>";
+        let fragment = Html::parse_fragment(html);
+        let sel = Selector::parse("a").unwrap();
+        let element = fragment.select(&sel).next().unwrap();
+        assert_eq!(true, element.is_link());
+
+        let html = "<p>hey there</p>";
+        let fragment = Html::parse_fragment(html);
+        let sel = Selector::parse("p").unwrap();
+        let element = fragment.select(&sel).next().unwrap();
+        assert_eq!(false, element.is_link());
+    }
+
+    #[test]
+    fn test_has_class() {
+        use html5ever::LocalName;
+        let html = "<p class='my_class'>hey there</p>";
+        let fragment = Html::parse_fragment(html);
+        let sel = Selector::parse("p").unwrap();
+        let element = fragment.select(&sel).next().unwrap();
+        assert_eq!(
+            true,
+            element.has_class(&LocalName::from("my_class"), CaseSensitivity::CaseSensitive)
+        );
+
+        let html = "<p>hey there</p>";
+        let fragment = Html::parse_fragment(html);
+        let sel = Selector::parse("p").unwrap();
+        let element = fragment.select(&sel).next().unwrap();
+        assert_eq!(
+            false,
+            element.has_class(&LocalName::from("my_class"), CaseSensitivity::CaseSensitive)
+        );
+}
+
+
+
+}

--- a/src/element_ref/element.rs
+++ b/src/element_ref/element.rs
@@ -1,11 +1,11 @@
 use selectors::{Element, OpaqueElement};
 use selectors::attr::{AttrSelectorOperation, CaseSensitivity, NamespaceConstraint};
 use selectors::context::VisitedHandlingMode;
-use html5ever::{Namespace, LocalName};
+use html5ever::{LocalName, Namespace};
 use selectors::matching;
 
 use super::ElementRef;
-use selector::{Simple, NonTSPseudoClass, PseudoElement};
+use selector::{NonTSPseudoClass, PseudoElement, Simple};
 
 /// Note: will never match against non-tree-structure pseudo-classes.
 impl<'a> Element for ElementRef<'a> {
@@ -84,8 +84,8 @@ impl<'a> Element for ElementRef<'a> {
         operation: &AttrSelectorOperation<&String>,
     ) -> bool {
         self.value().attrs.iter().any(|(key, value)| {
-            !matches!(*ns, NamespaceConstraint::Specific(url) if *url != key.ns) &&
-                *local_name == key.local && operation.eval_str(value)
+            !matches!(*ns, NamespaceConstraint::Specific(url) if *url != key.ns)
+                && *local_name == key.local && operation.eval_str(value)
         })
     }
 
@@ -114,7 +114,6 @@ impl<'a> Element for ElementRef<'a> {
             None => false,
         }
     }
-
 }
 
 #[cfg(test)]
@@ -188,8 +187,6 @@ mod tests {
             false,
             element.has_class(&LocalName::from("my_class"), CaseSensitivity::CaseSensitive)
         );
-}
-
-
+    }
 
 }

--- a/src/element_ref/element.rs
+++ b/src/element_ref/element.rs
@@ -98,10 +98,7 @@ impl<'a> Element for ElementRef<'a> {
     }
 
     fn is_link(&self) -> bool {
-        match self.value().attr("href") {
-            Some(_) => true,
-            None => false,
-        }
+        self.value().attr("href").is_some()
     }
 
     fn opaque(&self) -> OpaqueElement {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,27 +123,19 @@
 //! assert_eq!(vec!["Hello, ", "world!"], text);
 //! ```
 
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    missing_copy_implementations,
-    trivial_casts,
-    trivial_numeric_casts,
-    unused_extern_crates,
-    unused_import_braces,
-    unused_qualifications,
-    variant_size_differences
-)]
+#![warn(missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
+        trivial_numeric_casts, unused_extern_crates, unused_import_braces, unused_qualifications,
+        variant_size_differences)]
 
-#[macro_use]
-extern crate matches;
 extern crate cssparser;
 extern crate ego_tree;
 #[macro_use]
 extern crate html5ever;
+#[macro_use]
+extern crate matches;
 extern crate selectors;
-extern crate tendril;
 extern crate smallvec;
+extern crate tendril;
 
 pub use html::Html;
 pub use node::Node;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,7 @@ extern crate ego_tree;
 extern crate html5ever;
 extern crate selectors;
 extern crate tendril;
+extern crate smallvec;
 
 pub use html::Html;
 pub use node::Node;

--- a/src/node.rs
+++ b/src/node.rs
@@ -8,6 +8,8 @@ use std::collections::{hash_set, hash_map};
 use html5ever::{QualName, LocalName, Attribute};
 use html5ever::tendril::StrTendril;
 
+use selectors::attr::CaseSensitivity;
+
 /// An HTML node.
 #[derive(Clone, PartialEq, Eq)]
 pub enum Node {
@@ -244,8 +246,9 @@ impl Element {
     }
 
     /// Returns true if element has the class.
-    pub fn has_class(&self, class: &str) -> bool {
-        self.classes.contains(&LocalName::from(class))
+    pub fn has_class(&self, class: &str, case_sensitive: CaseSensitivity) -> bool {
+        self.classes()
+            .any(|c| case_sensitive.eq(c.as_bytes(), class.as_bytes()))
     }
 
     /// Returns an iterator over the element's classes.

--- a/src/node.rs
+++ b/src/node.rs
@@ -2,10 +2,10 @@
 
 use std::fmt;
 use std::ops::Deref;
-use std::collections::{HashSet, HashMap};
-use std::collections::{hash_set, hash_map};
+use std::collections::{HashMap, HashSet};
+use std::collections::{hash_map, hash_set};
 
-use html5ever::{QualName, LocalName, Attribute};
+use html5ever::{Attribute, LocalName, QualName};
 use html5ever::tendril::StrTendril;
 
 use selectors::attr::CaseSensitivity;
@@ -38,57 +38,90 @@ pub enum Node {
 impl Node {
     /// Returns true if node is the document root.
     pub fn is_document(&self) -> bool {
-        match *self { Node::Document => true, _ => false }
+        match *self {
+            Node::Document => true,
+            _ => false,
+        }
     }
 
     /// Returns true if node is the fragment root.
     pub fn is_fragment(&self) -> bool {
-        match *self { Node::Fragment => true, _ => false }
+        match *self {
+            Node::Fragment => true,
+            _ => false,
+        }
     }
 
     /// Returns true if node is a doctype.
     pub fn is_doctype(&self) -> bool {
-        match *self { Node::Doctype(_) => true, _ => false }
+        match *self {
+            Node::Doctype(_) => true,
+            _ => false,
+        }
     }
 
     /// Returns true if node is a comment.
     pub fn is_comment(&self) -> bool {
-        match *self { Node::Comment(_) => true, _ => false }
+        match *self {
+            Node::Comment(_) => true,
+            _ => false,
+        }
     }
 
     /// Returns true if node is text.
     pub fn is_text(&self) -> bool {
-        match *self { Node::Text(_) => true, _ => false }
+        match *self {
+            Node::Text(_) => true,
+            _ => false,
+        }
     }
 
     /// Returns true if node is an element.
     pub fn is_element(&self) -> bool {
-        match *self { Node::Element(_) => true, _ => false }
+        match *self {
+            Node::Element(_) => true,
+            _ => false,
+        }
     }
 
     /// Returns self as a doctype.
     pub fn as_doctype(&self) -> Option<&Doctype> {
-        match *self { Node::Doctype(ref d) => Some(d), _ => None }
+        match *self {
+            Node::Doctype(ref d) => Some(d),
+            _ => None,
+        }
     }
 
     /// Returns self as a comment.
     pub fn as_comment(&self) -> Option<&Comment> {
-        match *self { Node::Comment(ref c) => Some(c), _ => None }
+        match *self {
+            Node::Comment(ref c) => Some(c),
+            _ => None,
+        }
     }
 
     /// Returns self as text.
     pub fn as_text(&self) -> Option<&Text> {
-        match *self { Node::Text(ref t) => Some(t), _ => None }
+        match *self {
+            Node::Text(ref t) => Some(t),
+            _ => None,
+        }
     }
 
     /// Returns self as an element.
     pub fn as_element(&self) -> Option<&Element> {
-        match *self { Node::Element(ref e) => Some(e), _ => None }
+        match *self {
+            Node::Element(ref e) => Some(e),
+            _ => None,
+        }
     }
 
     /// Returns self as an element.
     pub fn as_processing_instruction(&self) -> Option<&ProcessingInstruction> {
-        match *self { Node::ProcessingInstruction(ref pi) => Some(pi), _ => None }
+        match *self {
+            Node::ProcessingInstruction(ref pi) => Some(pi),
+            _ => None,
+        }
     }
 }
 
@@ -210,11 +243,10 @@ pub struct Element {
 impl Element {
     #[doc(hidden)]
     pub fn new(name: QualName, attrs: Vec<Attribute>) -> Self {
-        let id = attrs.iter().find(|a| a.name.local.deref() == "id").map(
-            |a| {
-                LocalName::from(a.value.deref())
-            },
-        );
+        let id = attrs
+            .iter()
+            .find(|a| a.name.local.deref() == "id")
+            .map(|a| LocalName::from(a.value.deref()));
 
         let classes: HashSet<LocalName> = attrs
             .iter()
@@ -253,7 +285,9 @@ impl Element {
 
     /// Returns an iterator over the element's classes.
     pub fn classes(&self) -> Classes {
-        Classes { inner: self.classes.iter() }
+        Classes {
+            inner: self.classes.iter(),
+        }
     }
 
     /// Returns the value of an attribute.
@@ -264,7 +298,9 @@ impl Element {
 
     /// Returns an iterator over the element's attributes.
     pub fn attrs(&self) -> Attrs {
-        Attrs { inner: self.attrs.iter() }
+        Attrs {
+            inner: self.attrs.iter(),
+        }
     }
 }
 

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -25,9 +25,9 @@ impl Selector {
 
     pub fn parse<'t, 'i>(
         selectors: &'i str,
-    ) -> Result<Self, cssparser::ParseError<'t, SelectorParseErrorKind<'i>>> {
-        let mut _selectors = cssparser::ParserInput::new(selectors);
-        let mut parser = cssparser::Parser::new(&mut _selectors);
+    ) -> Result<Self, cssparser::ParseError<'i, SelectorParseErrorKind<'i>>> {
+        let mut parser_input = cssparser::ParserInput::new(selectors);
+        let mut parser = cssparser::Parser::new(&mut parser_input);
         parser::SelectorList::parse(&Parser, &mut parser).map(|list| Selector { selectors: list.0 })
     }
 

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -72,23 +72,14 @@ impl parser::SelectorImpl for Simple {
     // see: https://github.com/servo/servo/pull/19747#issuecomment-357106065
     type ExtraMatchingData = String;
 
-    fn is_active_or_hover(pc: &NonTSPseudoClass) -> bool {
-        matches!(*pc, NonTSPseudoClass::Active | NonTSPseudoClass::Hover)
+    fn is_active_or_hover(_pc: &NonTSPseudoClass) -> bool {
+        false
     }
 }
 
 /// Non Tree-Structural Pseudo-Class.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum NonTSPseudoClass {
-    /// Unvisited links
-    Link,
-    /// Visited links
-    Visited,
-    /// user hovers
-    Hover,
-    /// active links
-    Active,
-}
+pub enum NonTSPseudoClass {}
 
 impl parser::Visit for NonTSPseudoClass {
     type Impl = Simple;

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -1,9 +1,13 @@
 //! CSS selectors.
 
 use std::fmt;
+
+use smallvec::SmallVec;
+
 use html5ever::{LocalName, Namespace};
 use cssparser;
 use selectors::{parser, matching, visitor};
+use selectors::parser::SelectorParseErrorKind;
 
 use ElementRef;
 
@@ -13,32 +17,35 @@ use ElementRef;
 #[derive(Debug, Clone, PartialEq)]
 pub struct Selector {
     /// The CSS selectors.
-    pub selectors: Vec<parser::Selector<Simple>>,
+    pub selectors: SmallVec<[parser::Selector<Simple>; 1]>,
 }
 
 impl Selector {
     /// Parses a CSS selector group.
-    ///
-    /// No meaningful error can be returned here, due to a limitation of the `selectors` and
-    /// `cssparser` crates.
-    pub fn parse(selectors: &str) -> Result<Self, ()> {
-        let mut parser = cssparser::Parser::new(selectors);
+
+    pub fn parse<'t, 'i>(
+        selectors: &'i str,
+    ) -> Result<Self, cssparser::ParseError<'t, SelectorParseErrorKind<'i>>> {
+        let mut _selectors = cssparser::ParserInput::new(selectors);
+        let mut parser = cssparser::Parser::new(&mut _selectors);
         parser::SelectorList::parse(&Parser, &mut parser).map(|list| Selector { selectors: list.0 })
     }
 
     /// Returns true if the element matches this selector.
     pub fn matches(&self, element: &ElementRef) -> bool {
-        let mut context = matching::MatchingContext::new(matching::MatchingMode::Normal, None);
+        let mut context = matching::MatchingContext::new(matching::MatchingMode::Normal, None, None, matching::QuirksMode::NoQuirks);
         self.selectors.iter().any(|s| {
-            matching::matches_selector(&s.inner, element, &mut context, &mut |_, _| {})
+            matching::matches_selector(&s, 0, None, element, &mut context, &mut |_, _| {})
         })
     }
 }
 
 /// An implementation of `Parser` for `selectors`
 struct Parser;
-impl parser::Parser for Parser {
+impl<'i> parser::Parser<'i> for Parser {
     type Impl = Simple;
+    type Error = SelectorParseErrorKind<'i>;
+
 }
 
 
@@ -58,13 +65,31 @@ impl parser::SelectorImpl for Simple {
 
     type NonTSPseudoClass = NonTSPseudoClass;
     type PseudoElement = PseudoElement;
+
+    // see: https://github.com/servo/servo/pull/19747#issuecomment-357106065
+    type ExtraMatchingData = String;
+
+    fn is_active_or_hover(pc: &NonTSPseudoClass) -> bool {
+        matches!(*pc, NonTSPseudoClass::Active | NonTSPseudoClass::Hover)
+    }
+
 }
 
 /// Non Tree-Structural Pseudo-Class.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum NonTSPseudoClass {}
+pub enum NonTSPseudoClass {
+    /// Unvisited links
+    Link,
+    /// Visited links
+    Visited,
+    /// user hovers
+    Hover,
+    /// active links
+    Active,
+}
 
-impl parser::SelectorMethods for NonTSPseudoClass {
+
+impl parser::Visit for NonTSPseudoClass {
     type Impl = Simple;
 
     fn visit<V>(&self, _visitor: &mut V) -> bool

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -6,7 +6,7 @@ use smallvec::SmallVec;
 
 use html5ever::{LocalName, Namespace};
 use cssparser;
-use selectors::{parser, matching, visitor};
+use selectors::{matching, parser, visitor};
 use selectors::parser::SelectorParseErrorKind;
 
 use ElementRef;
@@ -33,10 +33,15 @@ impl Selector {
 
     /// Returns true if the element matches this selector.
     pub fn matches(&self, element: &ElementRef) -> bool {
-        let mut context = matching::MatchingContext::new(matching::MatchingMode::Normal, None, None, matching::QuirksMode::NoQuirks);
-        self.selectors.iter().any(|s| {
-            matching::matches_selector(&s, 0, None, element, &mut context, &mut |_, _| {})
-        })
+        let mut context = matching::MatchingContext::new(
+            matching::MatchingMode::Normal,
+            None,
+            None,
+            matching::QuirksMode::NoQuirks,
+        );
+        self.selectors
+            .iter()
+            .any(|s| matching::matches_selector(&s, 0, None, element, &mut context, &mut |_, _| {}))
     }
 }
 
@@ -45,9 +50,7 @@ struct Parser;
 impl<'i> parser::Parser<'i> for Parser {
     type Impl = Simple;
     type Error = SelectorParseErrorKind<'i>;
-
 }
-
 
 /// A simple implementation of `SelectorImpl` with no pseudo-classes or pseudo-elements.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -72,7 +75,6 @@ impl parser::SelectorImpl for Simple {
     fn is_active_or_hover(pc: &NonTSPseudoClass) -> bool {
         matches!(*pc, NonTSPseudoClass::Active | NonTSPseudoClass::Hover)
     }
-
 }
 
 /// Non Tree-Structural Pseudo-Class.
@@ -87,7 +89,6 @@ pub enum NonTSPseudoClass {
     /// active links
     Active,
 }
-
 
 impl parser::Visit for NonTSPseudoClass {
     type Impl = Simple;


### PR DESCRIPTION
Hello @programble , here is my take at updating `scraper` to use the latest mozilla css parser lib `selector==0.19`; that took me the most part of the time since the other libs could be effortlessy updated.

I'd like your opinion on this pr since I'm not very knowledgeable on Rust. I'll add a couple of comments in my patch to explain a couple of things