### PR TITLE
Update cssparser dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/programble/scraper"
 readme = "README.md"
 
 [dependencies]
-cssparser = "0.25.3"
+cssparser = "0.25.9"
 ego-tree = "0.6.0"
 html5ever = "0.22.0"
 matches = "0.1.6"


### PR DESCRIPTION
This version of cssparser doesn't compile on newer Rust versions.