### PR TITLE
Add version flag in executable

### DIFF
--- a/scraper/src/main.rs
+++ b/scraper/src/main.rs
@@ -66,6 +66,7 @@ fn main() {
     opts.optflag("t", "text", "output text of elements");
     opts.optflag("h", "help", "this cruft");
     opts.optopt("", "install-man-page", "install real documentation", "PATH");
+    opts.optflag("", "version", "output version number");
 
     let args: Vec<String> = env::args().collect();
     let matches = match opts.parse(&args[1..]) {
@@ -77,6 +78,10 @@ fn main() {
             "{}",
             opts.usage("Usage: scraper [options] SELECTOR [FILE ...]")
         );
+        return;
+    }
+    if matches.opt_present("version") {
+        println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
         return;
     }
 


### PR DESCRIPTION
The version output is simple but useful for smoke tests, especially for package managers.

For example, [nixpkgs](https://github.com/NixOS/nixpkgs/blob/5ab00c93e240a9318c945db85877ec51708887b0/pkgs/by-name/sc/scraper/package.nix) has testing helpers, such as [versionCheckHook](https://github.com/NixOS/nixpkgs/blob/5ab00c93e240a9318c945db85877ec51708887b0/doc/hooks/versionCheckHook.section.md) and [testVersion](https://github.com/NixOS/nixpkgs/blob/5ab00c93e240a9318c945db85877ec51708887b0/doc/stdenv/passthru.chapter.md?plain=1#L82-L86), that use this output.

I omitted the short option such as `v` in this PR.
 
After this change

```console
> ./target/debug/scraper --version
scraper 0.24.0

> ./target/debug/scraper --help
Usage: scraper [options] SELECTOR [FILE ...]

Options:
    -H, --html          output HTML of elements
    -I, --inner-html    output inner HTML of elements
    -a, --attr ATTR     output attribute value of elements
    -c, --classes       output classes of elements
    -d, --document      parse input as HTML documents
    -f, --fragment      parse input as HTML fragments
    -i, --id            output ID of elements
    -n, --name          output name of elements
    -t, --text          output text of elements
    -h, --help          this cruft
        --install-man-page PATH
                        install real documentation
        --version       output version number
```