### PR TITLE
Avoid panic for unknown flags and invalid selectors when using executable

### DIFF
--- a/scraper/src/main.rs
+++ b/scraper/src/main.rs
@@ -124,10 +124,16 @@ fn main() {
         Output::Html
     };
 
-    let selector = matches.free.first().expect("missing selector");
+    let selector = matches.free.first().unwrap_or_else(|| {
+        eprintln!("missing selector");
+        process::exit(USAGE);
+    });
     let files = &matches.free[1..];
 
-    let selector = Selector::parse(selector).unwrap();
+    let selector = Selector::parse(selector).unwrap_or_else(|e| {
+        eprintln!("failed to parse selector: {}", e);
+        process::exit(USAGE);
+    });
 
     let matched = if files.is_empty() {
         query(&input, &output, &selector, &mut io::stdin())


### PR DESCRIPTION
This PR aims to reduce panic occurrences caused by incorrect user options.
This prevents surprising new users who are not familiar with the tool.

Before

```console
> ./target/debug/scraper --unknown

thread 'main' panicked at scraper/src/main.rs:73:19:
Unrecognized option: 'unknown'
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

> curl -s https://learn.microsoft.com/en-gb/typography/opentype/spec/scripttags | ./target/debug/scraper

thread 'main' panicked at scraper/src/main.rs:116:41:
missing selector
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After


```console
> ./target/debug/scraper --unknown
Unrecognized option: 'unknown'

> curl -s https://learn.microsoft.com/en-gb/typography/opentype/spec/scripttags | ./target/debug/scraper
missing selector
```