### PR TITLE
Bump html5ever from 0.37.1 to 0.38.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,9 +108,9 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "html5ever"
-version = "0.37.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5935f02fdc02823ff15fec27c2b3d7ca19d629e996f7a0ae4d7d500e62e54c76"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
 dependencies = [
  "log",
  "markup5ever",
@@ -155,9 +155,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "markup5ever"
-version = "0.37.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cfb33ea12d5d83b1ba9a55ae7d05faec4f2189d47b79c04d4cea6bbe9f5b083"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
 dependencies = [
  "log",
  "tendril",

--- a/scraper/Cargo.toml
+++ b/scraper/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 [dependencies]
 cssparser = "0.36.0"
 ego-tree = "0.11.0"
-html5ever = "0.37.1"
+html5ever = "0.38.0"
 indexmap = { version = "2.13.0", optional = true }
 precomputed-hash = "0.1.1"
 selectors = "0.35.0"

--- a/scraper/src/html/tree_sink.rs
+++ b/scraper/src/html/tree_sink.rs
@@ -294,13 +294,4 @@ impl TreeSink for HtmlTreeSink {
             self.append(prev_element, child)
         }
     }
-
-    fn clone_subtree(&self, target: &Self::Handle) -> Self::Handle {
-        let mut html = self.0.borrow_mut();
-
-        let mut source_node = html.tree.get_mut(*target).unwrap();
-        let cloned_subtree = source_node.clone_subtree();
-
-        cloned_subtree.id()
-    }
 }


### PR DESCRIPTION
Get fixes for https://github.com/servo/html5ever/issues/716

Note that I tried Copilot for this but I think this should be fine. Also kind of unfortunate that html5ever does not seem to tag releases any more and also doesn't seem to produce changelogs.