### PR TITLE
Document how to make the library `Send` in `README.md`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,6 @@ dependencies = [
  "precomputed-hash",
  "selectors",
  "serde",
- "tendril",
 ]
 
 [[package]]

--- a/scraper/Cargo.toml
+++ b/scraper/Cargo.toml
@@ -21,7 +21,6 @@ indexmap = { version = "2.14.0", optional = true }
 precomputed-hash = "0.1.1"
 selectors = "0.38.0"
 serde = { version = "1.0.228", optional = true }
-tendril = "0.5.0"
 
 [dependencies.getopts]
 version = "0.2.24"

--- a/scraper/README.md
+++ b/scraper/README.md
@@ -154,7 +154,7 @@ The `html5ever` crate uses the
 type as their reference counted string. By default, it's thread-local and thus
 `!Send`, enabling the `atomic` flag will use the atomic counting version of
 [`Tendril`](https://docs.rs/html5ever/latest/html5ever/tendril/struct.Tendril.html),
-implementing `Send` and allow the use across threads.
+implementing `Send` and allow their use across threads.
 ```toml
 [dependencies]
 scraper = { version = "0.27.0", features = ["atomic"] }

--- a/scraper/README.md
+++ b/scraper/README.md
@@ -148,6 +148,14 @@ let document = tree.finish();
 assert_eq!(document.html(), "<html><head></head><body>hello</body></html>");
 ```
 
+### Using the library across threads
+By default, many types of this library are `!Send` due to some internal data
+structures used. To make them `Send`, enable the `atomic` feature flag.
+```toml
+[dependencies]
+scraper = { version = "0.27.0", features = ["atomic"] }
+```
+
 ## Contributing
 
 Please feel free to open pull requests. If you're planning on implementing

--- a/scraper/README.md
+++ b/scraper/README.md
@@ -149,8 +149,12 @@ assert_eq!(document.html(), "<html><head></head><body>hello</body></html>");
 ```
 
 ### Using the library across threads
-By default, many types of this library are `!Send` due to some internal data
-structures used. To make them `Send`, enable the `atomic` feature flag.
+The `html5ever` crate uses the
+[`Tendril`](https://docs.rs/html5ever/latest/html5ever/tendril/struct.Tendril.html)
+type as their reference counted string. By default, it's thread-local and thus
+`!Send`, enabling the `atomic` flag will use the atomic counting version of
+[`Tendril`](https://docs.rs/html5ever/latest/html5ever/tendril/struct.Tendril.html),
+implementing `Send` and allow the use across threads.
 ```toml
 [dependencies]
 scraper = { version = "0.27.0", features = ["atomic"] }

--- a/scraper/src/html/mod.rs
+++ b/scraper/src/html/mod.rs
@@ -11,7 +11,7 @@ use html5ever::serialize::SerializeOpts;
 use html5ever::tree_builder::QuirksMode;
 use html5ever::{QualName, driver, serialize};
 use selectors::matching::SelectorCaches;
-use tendril::TendrilSink;
+use html5ever::tendril::TendrilSink;
 
 use crate::selector::Selector;
 use crate::{ElementRef, Node};
@@ -65,12 +65,11 @@ impl Html {
     /// ```
     /// # extern crate html5ever;
     /// # extern crate scraper;
-    /// # extern crate tendril;
     /// # fn main() {
     /// # let document = "";
     /// use html5ever::driver::{self, ParseOpts};
     /// use scraper::{Html, HtmlTreeSink};
-    /// use tendril::TendrilSink;
+    /// use html5ever::tendril::TendrilSink;
     ///
     /// let parser = driver::parse_document(HtmlTreeSink::new(Html::new_document()), ParseOpts::default());
     /// let html = parser.one(document);

--- a/scraper/src/html/mod.rs
+++ b/scraper/src/html/mod.rs
@@ -8,10 +8,10 @@ use std::iter::FusedIterator;
 use ego_tree::Tree;
 use ego_tree::iter::Nodes;
 use html5ever::serialize::SerializeOpts;
+use html5ever::tendril::TendrilSink;
 use html5ever::tree_builder::QuirksMode;
 use html5ever::{QualName, driver, serialize};
 use selectors::matching::SelectorCaches;
-use html5ever::tendril::TendrilSink;
 
 use crate::selector::Selector;
 use crate::{ElementRef, Node};

--- a/scraper/src/html/mod.rs
+++ b/scraper/src/html/mod.rs
@@ -68,8 +68,8 @@ impl Html {
     /// # fn main() {
     /// # let document = "";
     /// use html5ever::driver::{self, ParseOpts};
-    /// use scraper::{Html, HtmlTreeSink};
     /// use html5ever::tendril::TendrilSink;
+    /// use scraper::{Html, HtmlTreeSink};
     ///
     /// let parser = driver::parse_document(HtmlTreeSink::new(Html::new_document()), ParseOpts::default());
     /// let html = parser.one(document);


### PR DESCRIPTION
I had been using the library along with tokio but always found the `Html` type wasn't `Send` annoying. Turns out a feature flag already existed that solved my problem but wasn't documented. This just documents it.

