### PR TITLE
upgrade selectors dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
+checksum = "bad7c25c97cc59c4858df8724a3789caa6ee509b628dfe6df34e8a8084c8a84e"
 dependencies = [
  "bitflags",
  "cssparser",

--- a/scraper/Cargo.toml
+++ b/scraper/Cargo.toml
@@ -19,7 +19,7 @@ ego-tree = "0.11.0"
 html5ever = "0.39.0"
 indexmap = { version = "2.14.0", optional = true }
 precomputed-hash = "0.1.1"
-selectors = "0.38.0"
+selectors = "0.39.0"
 serde = { version = "1.0.228", optional = true }
 
 [dependencies.getopts]


### PR DESCRIPTION
The new version of selectors is still using the same cssparser version.